### PR TITLE
Slight doc and bug fixes for using this on a new project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vagrant
 npm-debug
+node_modules

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ of abstractions. It relies heavily on [pg-promise](https://www.npmjs.com/package
 1. Run `npm install` to install local dependencies.
 2. Run `vagrant up` to set up postgresql database.
 3. Run `npm run migrate:up` to initialize the database.
-4. Run `npm start-dev` to start the api.
+4. Run `npm run start-dev` to start the api.
 5. Browse to <http://localhost:8000/>
 6. Edit files in `src/api` (the server will automatically restart on changes).
 

--- a/deploy/ansible/host_vars/api-staging.example.com
+++ b/deploy/ansible/host_vars/api-staging.example.com
@@ -1,0 +1,3 @@
+env: staging
+hostname: api-staging.example.com
+site_fqdn: api-staging.example.com

--- a/deploy/ansible/host_vars/api-staging.tkellen.com
+++ b/deploy/ansible/host_vars/api-staging.tkellen.com
@@ -1,3 +1,0 @@
-env: staging
-hostname: api-staging.tkellen.com
-site_fqdn: api-staging.tkellen.com

--- a/deploy/ansible/host_vars/vagrant
+++ b/deploy/ansible/host_vars/vagrant
@@ -9,7 +9,7 @@ env: development
 # Vagrant box synced folder. This should match the config.vm.synced_folder
 # setting in the Vagrantfile, and should be different than the site_path,
 # clone_path or public_path vars.
-synced_folder: "{{base_path}}/vagrant"
+synced_folder: "{{base_path}}/api"
 
 # Vagrant box hostname and FQDN. The site_fqdn setting should match the vagrant
 # inventory ansible_ssh_host and Vagrantfile config.hostsupdater.aliases

--- a/deploy/ansible/inventory/production
+++ b/deploy/ansible/inventory/production
@@ -1,4 +1,4 @@
 # Specify your production app server here. This should match the ansible
 # group_vars/all site_fqdn setting.
 
-api.tkellen.com
+api.example.com

--- a/deploy/ansible/inventory/staging
+++ b/deploy/ansible/inventory/staging
@@ -3,4 +3,4 @@
 # production server's FQDN. This is likely the only change you will need to
 # make between production and staging.
 
-staging-api.tkellen.com site_fqdn=staging-api.tkellen.com
+staging-api.example.com site_fqdn=staging-api.example.com

--- a/deploy/ansible/roles/nginx/templates/site.conf
+++ b/deploy/ansible/roles/nginx/templates/site.conf
@@ -5,7 +5,7 @@ upstream api {
 server {
   listen 80;
   include gzip_params;
-  server_name {{site_fqdn}} votetracker.berniesanders.com;
+  server_name {{site_fqdn}};
   root {{public_path}};
   index index.html;
   error_page 404 /404.html;

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "body-parser": "^1.15.0",
     "careen": "^0.1.1",
     "dotenv": "^2.0.0",
+    "express": "^4.13.4",
     "express-routebuilder": "^2.1.0",
     "is-my-json-valid": "^2.13.1",
     "morgan": "^1.7.0",


### PR DESCRIPTION
 - missing express
 - a lack of a public directory throws 500 errors
 - the vagrant link and the vagrant synced folder were different
 - changed tkellen hostnames to example hostnames for people who wouldn’t assume what to do there
 - removed the default FQDN of vote tracker 
 - Added node_modules to gitignore