### PR TITLE
Update sql.js

### DIFF
--- a/src/base/sql.js
+++ b/src/base/sql.js
@@ -6,7 +6,7 @@ import pgp from 'pg-promise';
 export function load(basePath) {
   return fs.readdirSync(basePath).reduce((result, queryFile) => {
     const query = path.basename(queryFile, '.sql');
-    result[query] = pgp.QueryFile(path.join(basePath, queryFile));
+    result[query] = pgp.QueryFile(path.join(basePath, queryFile), {minify: true});
     return result;
   }, {});
 }


### PR DESCRIPTION
Use of at least option `minify` is a good idea. You can end up with large SQL, with comments or even multiple versions commented out, and you don't want all that end up being executed and then shown in pg-monitor. Also, it will pre-parse your SQL for errors.